### PR TITLE
Fixing some startup errors

### DIFF
--- a/src/jamuz/gui/PanelOptions.java
+++ b/src/jamuz/gui/PanelOptions.java
@@ -63,7 +63,10 @@ public class PanelOptions extends javax.swing.JPanel {
 		progressBarCheckedFlag = (ProgressBar)jProgressBarResetChecked;
 		jListGenres.setModel(Jamuz.getGenreListModel());
 		jListTags.setModel(Jamuz.getTagsModel());
-		jSpinnerBytes.getModel().setValue(Long.valueOf(Jamuz.getOptions().get("log.cleanup.keep.size.bytes")));
+		if(!Jamuz.getOptions().get("log.cleanup.keep.size.bytes").equals("{Missing}"))
+		{
+			jSpinnerBytes.getModel().setValue(Long.valueOf(Jamuz.getOptions().get("log.cleanup.keep.size.bytes")));
+		};
 	}
 	
 	public static void fillMachineList() {

--- a/src/jamuz/process/video/ProcessVideo.java
+++ b/src/jamuz/process/video/ProcessVideo.java
@@ -203,6 +203,13 @@ public class ProcessVideo extends ProcessAbstract {
         }
 
 		//Connect to database
+		
+		//Checks if database is configured
+		if (Jamuz.getOptions().get("video.dbLocation") != null) {
+			Popup.info("No Video Database configured");
+			return false;
+		}
+
 		DbConnVideo connKodi = new DbConnVideo(new DbInfo(DbInfo.LibType.Sqlite, 
 				Jamuz.getOptions().get("video.dbLocation"), ".", "."), 
 				Jamuz.getOptions().get("video.rootPath"));

--- a/src/jamuz/remote/Server.java
+++ b/src/jamuz/remote/Server.java
@@ -472,6 +472,10 @@ public class Server {
 	public void fillClients() {
 		try {
 			tableModel.clear();
+			//checks if RemoteClients.txt exists
+			if(!Jamuz.getFile("RemoteClients.txt", "data").exists()){
+				return;
+			}
 			Scanner sc = new Scanner(Jamuz.getFile("RemoteClients.txt", "data"));
 			while(sc.hasNext()){
 				String line = sc.nextLine().trim();


### PR DESCRIPTION
I tried to fix some errors occurring on startup because some files do not exist by default or some options are not set.

I tried my best and was able to get rid of the errors but i would recommend you to go through the code and maybe fix these errors in some upper sections to save runtime or to avoid other errors.

Errors:

- ProcessVideo.java:

> SCHWERWIEGEND: Fehler beim verbinden zur Datenbank. "************\JaMuz\logs\"
   (English translation: serious: error while connecting to database. "************\JaMuz\logs\")
java.sql.SQLException: [SQLITE_CANTOPEN]  Unable to open the database file (out of memory)
	at org.sqlite.DB.newSQLException(DB.java:383)
	at org.sqlite.DB.newSQLException(DB.java:387)
	at org.sqlite.DB.throwex(DB.java:374)
	at org.sqlite.NativeDB._open(Native Method)
	at org.sqlite.DB.open(DB.java:86)
	at org.sqlite.Conn.open(Conn.java:140)
	at org.sqlite.Conn.<init>(Conn.java:57)
	at org.sqlite.JDBC.createConnection(JDBC.java:77)
	at org.sqlite.JDBC.connect(JDBC.java:64)
	at java.sql.DriverManager.getConnection(DriverManager.java:664)
	at java.sql.DriverManager.getConnection(DriverManager.java:208)
	at jamuz.DbConn.connect(DbConn.java:78)
	at jamuz.process.video.ProcessVideo.listDbfiles(ProcessVideo.java:244)
	at jamuz.process.video.ProcessVideo.access$400(ProcessVideo.java:40)
	at jamuz.process.video.ProcessVideo$ProcessListDb.run(ProcessVideo.java:170)

- Server.java:

> jamuz.remote.Server fillClients
SCHWERWIEGEND: null
java.io.FileNotFoundException: ********************\JaMuz\data\RemoteClients.txt (The System can't find the file)
	at java.io.FileInputStream.open0(Native Method)
	at java.io.FileInputStream.open(FileInputStream.java:195)
	at java.io.FileInputStream.<init>(FileInputStream.java:138)
	at java.util.Scanner.<init>(Scanner.java:611)
	at jamuz.remote.Server.fillClients(Server.java:478)
	at jamuz.remote.PanelRemote.initExtended(PanelRemote.java:74)
	at jamuz.gui.PanelMain.<init>(PanelMain.java:216)
	at jamuz.gui.PanelMain.lambda$main$11(PanelMain.java:1847)
	at jamuz.gui.PanelMain$$Lambda$13/1586600255.run(Unknown Source)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:749)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:702)
	at java.awt.EventQueue$3.run(EventQueue.java:696)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:75)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:719)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)

- PanelOptions.java:

> Exception in thread "AWT-EventQueue-0" java.lang.NumberFormatException: For input string: "{Missing}"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Long.parseLong(Long.java:589)
	at java.lang.Long.valueOf(Long.java:803)
	at jamuz.gui.PanelOptions.initExtended(PanelOptions.java:68)
	at jamuz.gui.PanelMain.<init>(PanelMain.java:209)
	at jamuz.gui.PanelMain.lambda$main$11(PanelMain.java:1847)
	at jamuz.gui.PanelMain$$Lambda$13/1586600255.run(Unknown Source)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:749)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:702)
	at java.awt.EventQueue$3.run(EventQueue.java:696)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:75)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:719)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)